### PR TITLE
Dynamically align columns on app column length

### DIFF
--- a/inotify-info.cpp
+++ b/inotify-info.cpp
@@ -584,11 +584,17 @@ static bool init_inotify_proclist( std::vector< procinfo_t > &inotify_proclist )
 
 static void print_inotify_proclist( std::vector< procinfo_t > &inotify_proclist )
 {
-    printf( "%s        Pid  App                        Watches   Instances%s\n", BCYAN, RESET );
+    unsigned int max_len = 0;
+    for ( procinfo_t &procinfo : inotify_proclist )
+            max_len = std::max( (unsigned int) procinfo.appname.length(), max_len);
+    const std::string header_padding = std::string(max_len-3 /* 'App' */, ' ');
+
+    printf( "%s        Pid  App%sWatches   Instances%s\n", BCYAN, header_padding.c_str(), RESET );
 
     for ( procinfo_t &procinfo : inotify_proclist )
     {
-        printf( "  % 10d %s%-30s%s %3u %3u\n", procinfo.pid,
+        std::string format = "  % 10d %s%-" + std::to_string(max_len) + "s%s %6u %3u\n";
+        printf( format.c_str(), procinfo.pid,
             BYELLOW, procinfo.appname.c_str(), RESET,
             procinfo.watches, procinfo.instances );
 


### PR DESCRIPTION
This closes issue #5 by dynamically aligning the output to the longest app name, as 30 was not sufficient. 
Another minor fix is upping the max number of watches from 1K-1 (3 digits) to 1M-1 (6 digits), as it is very common to have many tens of thousands of watches in a normal frontend project (as seen in the output below). This should allow for the normal case, plus more extreme cases :)

_Regard this as work-in-progress_ as I just made it work and will then wait on feedback for how to "do this the proper C++ way". For instance, I am not sure how I can dynamically set the column width and still retian argument checking for the `printf` function. I also suspect there are better ways of comparing `size_t`/`size_type` and `unsigned int`, getting the max value of a field in a list of objects, etc.

# Before
![image](https://user-images.githubusercontent.com/618076/234296229-7124e384-d04c-479d-af91-eaabaa03bb0b.png)

# After
![image](https://user-images.githubusercontent.com/618076/234296380-dc008cde-ed18-4e28-8140-91db4f7f0b03.png)

