### PR TITLE
Backwards compatibility with linux pre 2.6.33

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ COMPILER = $(shell $(CC) -v 2>&1 | grep -q "clang version" && echo clang || echo
 WARNINGS = -Wall -Wextra -Wpedantic -Wmissing-include-dirs -Wformat=2 -Wshadow
 ifneq ($(COMPILER),clang)
   # https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
-  WARNINGS += -Wsuggest-attribute=format -Wimplicit-fallthrough=2
+  WARNINGS += -Wsuggest-attribute=format -Wall
 endif
 
 CFLAGS = $(WARNINGS) -march=native -fno-exceptions -gdwarf-4 -g2 -ggnu-pubnames -gsplit-dwarf

--- a/inotify-info.cpp
+++ b/inotify-info.cpp
@@ -354,7 +354,7 @@ static void inotify_parse_fddir( procinfo_t &procinfo )
             filename = string_format( "/proc/%d/fd/%s", procinfo.pid, dp_fd->d_name );
             filename = get_link_name( filename.c_str() );
 
-            if ( filename == "anon_inode:inotify" )
+            if ( filename == "anon_inode:inotify" || filename == "inotify" )
             {
                 filename = string_format( "/proc/%d/fdinfo/%s", procinfo.pid, dp_fd->d_name );
 


### PR DESCRIPTION
This series of 3 commits implements:

* Compatibility with kernels older than 2.6.33
   - prior to this, instead of "`anon_inode:inotify`" linux used "`inotify`" as filename in /proc/.../fd

* Compatibility with kernels older than 3.8
  - prior to this, the /proc/.../fdinfo/... files did not include a list of inotify watches
  - the "Watches" column is omitted on older kernels

* Compatibility with GCC older than 7.1
  - prior to this, GCC did not support the `-Wimplicit-fallthrough=` argument
 
This PR also resolves my concern in https://github.com/mikesart/inotify-info/issues/10#issuecomment-1876581501 about missing info on old kernels

__Please merge this PR rather than rebase.__