### PR TITLE
Update Dockerfile - slim build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM debian:stable-slim
 
 RUN apt-get update \
  && apt-get install build-essential -y \
@@ -11,4 +11,7 @@ COPY . .
 
 RUN make
 
-CMD ./_release/inotify-info
+FROM debian:stable-slim
+COPY --from=0 /inotify-info/_release/inotify-info /bin/inotify-info
+
+CMD /bin/inotify-info


### PR DESCRIPTION
Use Docker multi-stage build to reduce docker image size from 527MB to 78.4MB - because why not! :)