### PR TITLE
dockerfile: even smaller build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,25 @@
-FROM debian:stable-slim
+FROM alpine
 
-RUN apt-get update \
- && apt-get install build-essential -y \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+# zig is installed from the upstream tarball, because:
+# - as of writing, alpine has zig only in testing (which is cumbersome to use)
+# - apk get zig pulls in libllvm, which is huge.
+#
+# Upstream tarball is statically linked, making it small and convenient to use.
+RUN apk add make \
+ && wget https://ziglang.org/download/0.11.0/zig-linux-$(uname -m)-0.11.0.tar.xz \
+ && tar -xJf zig-linux-*.tar.xz \
+ && rm zig-linux-*.xz \
+ && mv zig-linux-* zig
 
 WORKDIR inotify-info
 
 COPY . .
 
-RUN make
+RUN CC="/zig/zig cc -target $(uname -m)-linux-musl" \
+    CXX="/zig/zig c++ -target $(uname -m)-linux-musl" \
+    make
 
-FROM debian:stable-slim
-COPY --from=0 /inotify-info/_release/inotify-info /bin/inotify-info
+FROM scratch
+COPY --from=0 /inotify-info/_release/inotify-info /inotify-info
 
-CMD /bin/inotify-info
+CMD /inotify-info


### PR DESCRIPTION
Since we're making a "small container game" anyway, this results in a 2.72MB container.

I *would* like to use a C++ toolchain akin to C's musl-gcc (which has everything set up to link against musl), but wasn't able to find a C++ compiler that can link to musl libc without too many hoops.

Zig can do that pretty easily, so here we go.