### PR TITLE
ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,51 @@
+---
+name: test
+on: [push]
+concurrency:
+  # Cancels pending runs when a PR gets updated.
+  group: ${{ github.head_ref || github.run_id }}-${{ github.actor }}
+  cancel-in-progress: true
+jobs:
+
+  build-with-gcc:
+    strategy:
+      matrix:
+        cfg: [debug, release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get install -y build-essential
+      - run: make CFG=${{ matrix.cfg}} -j$(nproc)
+      - run: _${{ matrix.cfg }}/inotify-info
+
+  build-with-zig:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          if [ ! -d zig-sdk ]; then
+            wget --progress=dot:mega \
+              https://ziglang.org/download/0.11.0/zig-linux-$(uname -m)-0.11.0.tar.xz \
+            && tar -xJf zig-linux-*.tar.xz \
+            && rm zig-linux-*.xz \
+            && mv zig-linux-* zig-sdk \
+            && ln -s zig-sdk/zig
+          fi
+      - uses: actions/cache@v4
+        with:
+          key: zig-sdk-and-cache-${{ hashFiles('.github/workflows/ci.yaml') }}
+          path: |
+            zig-sdk
+            ~/.cache/zig
+      - run: make -j$(nproc)
+        env:
+          CC: ./zig cc -target x86_64-linux-musl
+          CXX: ./zig c++ -target x86_64-linux-musl
+      - run: _release/inotify-info
+
+  build-with-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build -t inotify-info .
+      - run: docker run --rm --privileged -v /proc:/proc inotify-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN CC="/zig/zig cc -target $(uname -m)-linux-musl" \
 FROM scratch
 COPY --from=0 /inotify-info/_release/inotify-info /inotify-info
 
-CMD /inotify-info
+ENTRYPOINT ["/inotify-info"]

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,6 @@ CXXFLAGS = -fno-rtti -Woverloaded-virtual
 LDFLAGS = -march=native -gdwarf-4 -g2 -Wl,--build-id=sha1
 LIBS = -Wl,--no-as-needed -lm -ldl -lpthread -lstdc++
 
-ifneq ("$(wildcard /usr/bin/ld.gold)","")
-  $(info Using gold linker...)
-  LDFLAGS += -fuse-ld=gold -Wl,--gdb-index
-endif
-
 CFILES = \
 	inotify-info.cpp \
 	lfqueue/lfqueue.c
@@ -70,7 +65,7 @@ endif
 ifeq ($(CFG), debug)
 	ODIR=_debug
 	CFLAGS += -O0 -DDEBUG
-	CFLAGS += -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -D_GLIBCXX_SANITIZE_VECTOR -D_LIBCPP_DEBUG=1
+	CFLAGS += -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -D_GLIBCXX_SANITIZE_VECTOR -D_LIBCPP_DEBUG=1 -D_LIBCPP_ENABLE_DEBUG_MODE=1
 else
 	ODIR=_release
 	CFLAGS += -O2 -DNDEBUG


### PR DESCRIPTION
Adding a simple github workflow. Main points:

- remove the implicit dependency on `/usr/bin/ld.gold`. If we want that, it should be a config-like option in the Makefile. @mikesart can you help me understand why it's desirable in the first place?
- fix the Dockerfile.
- `D_LIBCPP_DEBUG` has been deprecated and replaced with `D_LIBCPP_ENABLE_DEBUG_MODE` in the clang version we use. I am not sure if we intend to run the debug build on ancient versions of gcc which do not have that option. Accepting feedback.