### PR TITLE
github actions: fix cache order

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          key: zig-sdk-and-cache-${{ hashFiles('.github/workflows/ci.yaml') }}
+          path: |
+            zig-sdk
+            ~/.cache/zig
       - run: |
           if [ ! -d zig-sdk ]; then
             wget --progress=dot:mega \
@@ -31,12 +37,6 @@ jobs:
             && mv zig-linux-* zig-sdk \
             && ln -s zig-sdk/zig
           fi
-      - uses: actions/cache@v4
-        with:
-          key: zig-sdk-and-cache-${{ hashFiles('.github/workflows/ci.yaml') }}
-          path: |
-            zig-sdk
-            ~/.cache/zig
       - run: make -j$(nproc)
         env:
           CC: ./zig cc -target x86_64-linux-musl

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 ---
 name: test
-on: [push]
+on:
+  push:
+  pull_request:
 concurrency:
   # Cancels pending runs when a PR gets updated.
   group: ${{ github.head_ref || github.run_id }}-${{ github.actor }}


### PR DESCRIPTION
First we need to get zig from cache (if exists), and only then, if it doesn't, download the tarball.