### PR TITLE
Add release automation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,22 @@
+---
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Archive
+        run: make inotify-info-${{ github.ref_name }}.tar.gz
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          files: inotify-info-${{ github.ref_name }}.tar.gz
+          generate_release_notes: true
+          draft: true
+          prerelease: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 _debug/
 _release/
+
+/inotify-info-v*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -109,3 +109,9 @@ clean:
 	$(VERBOSE_PREFIX)$(RM) $(OBJS)
 	$(VERBOSE_PREFIX)$(RM) $(OBJS:.o=.d)
 	$(VERBOSE_PREFIX)$(RM) $(OBJS:.o=.dwo)
+
+define RELEASE_RULES
+inotify-info-$(TAG).tar.gz:
+	git archive --prefix=inotify-info-$(TAG)/ $(TAG) | gzip -n > $$@
+endef
+$(foreach TAG,$(shell git tag 2>/dev/null),$(eval $(RELEASE_RULES)))


### PR DESCRIPTION
Once a tag is pushed to github, it will:

- create a "release archive"
- create the release with the release archive

The release will be a "pre-release draft", so a human will need to go and make it "latest and greatest".

Example what happened in my fork when I pushed the tag: https://github.com/motiejus/inotify-info/actions/runs/8833871736/job/24254232221 https://github.com/motiejus/inotify-info/releases/tag/untagged-821f6dd9487d26fa828c

Fixes #23