### PR TITLE
release binaries: make them identical to github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 _debug/
 _release/
 
-/inotify-info-v*.tar.gz
+/inotify-info-*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ else
 endif
 
 PROJ = $(ODIR)/$(NAME)
-$(info Building $(ODIR)/$(NAME)...)
 
 ifeq ($(VERBOSE), 1)
 	VERBOSE_PREFIX=
@@ -112,6 +111,6 @@ clean:
 
 define RELEASE_RULES
 inotify-info-$(TAG).tar.gz:
-	git archive --prefix=inotify-info-$(TAG)/ $(TAG) | gzip -n > $$@
+	git archive --prefix=inotify-info-$(TAG)/ v$(TAG) | gzip -n > $$@
 endef
-$(foreach TAG,$(shell git tag 2>/dev/null),$(eval $(RELEASE_RULES)))
+$(foreach TAG,$(shell git tag | sed -n '/^v/ s/^v//p' 2>/dev/null),$(eval $(RELEASE_RULES)))


### PR DESCRIPTION
Github generated `inotify-info-0.0.1.tar.gz`, even though tag name was `v.0.0.1`. This change makes them equivalent (byte-by-byte identical).