### PR TITLE
INOTIFYINFO_VERSION: be stricter requiring it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ endif
 
 CFLAGS = $(WARNINGS) -march=native -fno-exceptions -gdwarf-4 -g2 -ggnu-pubnames -gsplit-dwarf
 CFLAGS += -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64
-CFLAGS += -DVERSION=\"$(INOTIFYINFO_VERSION)\"
+CFLAGS += -DINOTIFYINFO_VERSION=\"$(INOTIFYINFO_VERSION)\"
 CXXFLAGS = -fno-rtti -Woverloaded-virtual
 LDFLAGS = -march=native -gdwarf-4 -g2 -Wl,--build-id=sha1
 LIBS = -Wl,--no-as-needed -lm -ldl -lpthread -lstdc++

--- a/inotify-info.cpp
+++ b/inotify-info.cpp
@@ -52,8 +52,8 @@
 #include "inotify-info.h"
 #include "lfqueue/lfqueue.h"
 
-#ifndef VERSION
-#define VERSION "unknown"
+#ifndef INOTIFYINFO_VERSION
+#error INOTIFYINFO_VERSION must be set
 #endif
 
 /*
@@ -992,7 +992,7 @@ static bool parse_ignore_dirs_file()
 
 static void print_version()
 {
-    printf("%s\n", VERSION);
+    printf("%s\n", INOTIFYINFO_VERSION);
 }
 
 static void print_usage(const char* appname)


### PR DESCRIPTION
Having thought about it more, one safeguard in the Makefile is enough. We should be more explicit about required arguments when compiling, and especially given it's trivial to set anyway.