### PR TITLE
zig: upgrade and get from alpine

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
           path: ~/.cache/zig
       - run: |
           wget --progress=dot:mega \
-            https://ziglang.org/download/0.11.0/zig-linux-$(uname -m)-0.11.0.tar.xz
+            https://ziglang.org/download/0.12.0/zig-linux-$(uname -m)-0.12.0.tar.xz
           tar -xJf zig-linux-*.tar.xz
           rm zig-linux-*.xz
           mv zig-linux-* zig-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,13 @@
-FROM alpine
+FROM alpine:edge
 
-# zig is installed from the upstream tarball, because:
-# - as of writing, alpine has zig only in testing (which is cumbersome to use)
-# - apk get zig pulls in libllvm, which is huge.
-#
-# Upstream tarball is statically linked, making it small and convenient to use.
-RUN apk add make \
- && wget https://ziglang.org/download/0.12.0/zig-linux-$(uname -m)-0.12.0.tar.xz \
- && tar -xJf zig-linux-*.tar.xz \
- && rm zig-linux-*.xz \
- && mv zig-linux-* zig
+RUN apk add make zig
 
 WORKDIR inotify-info
 
 COPY . .
 
-RUN CC="/zig/zig cc -target $(uname -m)-linux-musl" \
-    CXX="/zig/zig c++ -target $(uname -m)-linux-musl" \
+RUN CC="zig cc -target $(uname -m)-linux-musl" \
+    CXX="zig c++ -target $(uname -m)-linux-musl" \
     make
 
 FROM scratch


### PR DESCRIPTION
Now that zig is in alpine, download it from the package manager in the Dockerfile. We will still have one version hardcoded, but oh well, someday.