### PR TITLE
ci/release: remove the release tarball from artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,15 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Archive
-        run: make inotify-info-${{ github.ref_name }}.tar.gz
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/v')
         with:
-          files: inotify-info-${{ github.ref_name }}.tar.gz
           generate_release_notes: true
           draft: true
           prerelease: true


### PR DESCRIPTION
The github artifacts from the API are reproducible; there is no need to redundantly generate and store them.