### PR TITLE
make install tuning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,21 +127,12 @@ clean:
 .PHONY: install
 
 install: all
-	$(MKDIR) $(BINDIR)
-	cp $(PROJ) $(BINDIR)/$(NAME)
-
+	install -D $(PROJ) $(BINDIR)/$(NAME)
 
 .PHONY: uninstall
 
 uninstall:
 	$(RM) $(BINDIR)/$(NAME)
-
-.PHONY: install-for-distro
-
-install-for-distro: all
-	$(MKDIR) /usr/bin
-	cp $(PROJ) /usr/bin/$(NAME)
-
 
 define RELEASE_RULES
 inotify-info-$(TAG).tar.gz:

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ Linking _debug/inotify-info...
 ```
 
 ## Install
-The resulting executable will be at `_release/inotify-info`. You are free to copy the resulting executable to any suitable location in your `$PATH`.
 
-Or run `$ make install` to install to `/usr/local/bin/`.
+The resulting executable will be at `_release/inotify-info`. You are free to
+copy the resulting executable to any suitable location in your `$PATH` or run
+`make install` to install to `/usr/local/bin`.
 
 ## Run (Prints Summary)
 ```


### PR DESCRIPTION
- use `install(1)` instead of `mkdir+cp`.
- remove `install-for-distro`, as it's nonstandard.